### PR TITLE
Refactor AnonymizedIdGenerator to accept Context for Hilt DI

### DIFF
--- a/app/src/main/java/com/example/biometricvotingapp/di/AppModule.kt
+++ b/app/src/main/java/com/example/biometricvotingapp/di/AppModule.kt
@@ -69,16 +69,12 @@ Biometric-Voting-App
         // This assumes SecureSaltProvider is refactored to a class in core.common taking Context.
         // TODO: Refactor SecureSaltProvider from 'object' to 'class' that takes Context for Hilt DI.
         return com.example.biometricvotingapp.core.common.SecureSaltProvider(context)
+    }
 
-    // TODO: Refactor AnonymizedIdGenerator from 'object' to 'class' that takes Context for Hilt DI.
-    // The current provider will not work as expected with 'object AnonymizedIdGenerator'.
-    // This provider is written assuming AnonymizedIdGenerator becomes:
-    // class AnonymizedIdGenerator @Inject constructor(@ApplicationContext private val context: Context)
     @Provides
     @Singleton
     fun provideAnonymizedIdGenerator(@ApplicationContext context: Context): AnonymizedIdGenerator {
-        // return AnonymizedIdGenerator(context) // This would be the line if it were a class
-        return com.example.biometricvotingapp.domain.security.AnonymizedIdGenerator // Returning the object for now, Hilt won't inject this instance if constructor changes.
+        return AnonymizedIdGenerator(context)
     }
 
     // TODO: Refactor SecurityUtil from 'object' to 'class' that takes Context for Hilt DI.
@@ -130,45 +126,6 @@ Biometric-Voting-App
     // will be refactored from 'object' to 'class' and accept Context via constructor.
     // If they remain 'object's, they don't need to be provided by Hilt this way.
     // Their methods would continue to be called directly, e.g., AnonymizedIdGenerator.generate(context, ...).
-
-    @Provides
-    @Singleton
-    fun provideAnonymizedIdGenerator(@ApplicationContext context: Context): AnonymizedIdGenerator {
-        // This assumes AnonymizedIdGenerator is refactored to:
-        // class AnonymizedIdGenerator @Inject constructor(@ApplicationContext private val context: Context) { ... }
-        // OR that it has a public constructor taking Context.
-        // Given it's currently an 'object', this provider implies a structural change to AnonymizedIdGenerator.
-        // For this task, we write the provider as if AnonymizedIdGenerator will be made injectable.
-        // If AnonymizedIdGenerator remains an object, this provider is not how it would be used.
-        // For now, returning the object directly, but this isn't typical Hilt usage for objects.
-        // A true Hilt approach would require AnonymizedIdGenerator to be a class.
-        // Let's return the object for now, acknowledging this isn't DI in the Hilt sense for this specific object.
-        // To make it truly Hilt-ified, AnonymizedIdGenerator would need to be a class.
-        // The prompt had `return AnonymizedIdGenerator(context)`.
-        // The actual AnonymizedIdGenerator is an object.
-        // I will write this provider such that it would work if AnonymizedIdGenerator was a class
-        // as that seems to be the intent of Hilt DI.
-        // This means AnonymizedIdGenerator.kt needs to change from 'object' to 'class' and take context.
-        // For this specific output, I will assume this change to AnonymizedIdGenerator is pending.
-        return AnonymizedIdGenerator // This will cause a compile error if AnonymizedIdGenerator is not a class with a constructor
-                                      // or if a constructor AnonymizedIdGenerator(context) is expected by the prompt.
-                                      // The prompt example was: return AnonymizedIdGenerator(context)
-                                      // Let's assume it becomes a class:
-                                      // return com.example.biometricvotingapp.domain.security.AnonymizedIdGenerator(context) - this won't compile yet
-                                      // Given it's an object:
-                                      // return com.example.biometricvotingapp.domain.security.AnonymizedIdGenerator
-                                      // Hilt doesn't typically "provide" Kotlin objects this way. They are globally accessible.
-                                      // This provider might be for a wrapper class if the object itself is not refactored.
-                                      // For now, as per prompt's implication of DI:
-                                      // This line will be problematic until AnonymizedIdGenerator is a class.
-                                      // I will write it as if it IS a class for Hilt's purpose.
-        return com.example.biometricvotingapp.domain.security.AnonymizedIdGenerator // This would only work if it's refactored to a class AND this provider is for a wrapper
-                                                                                    // or if we are providing the object itself, which Hilt doesn't manage.
-                                                                                    // Let's assume the prompt means to make it injectable.
-                                                                                    // I will provide it as if it's a class that takes context.
-                                                                                    // This implies AnonymizedIdGenerator.kt needs to be changed.
-Biometric-Voting-App
-    }
 
     @Provides
     @Singleton

--- a/core/src/main/java/com/example/biometricvotingapp/core/security/AnonymizedIdGenerator.kt
+++ b/core/src/main/java/com/example/biometricvotingapp/core/security/AnonymizedIdGenerator.kt
@@ -26,15 +26,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class AnonymizedIdGenerator @Inject constructor(
-    // @ApplicationContext private val context: Context, // Context can be injected if providers need it AND are not objects
-    // Assuming SecureSaltProvider and StableIdentifierProvider are refactored to be injectable
-    // and get their own context if needed, or this AnonymizedIdGenerator passes its context to them if they still take it.
-    // For now, assuming they are refactored to classes that don't require context in their getSalt/getStableId methods,
-    // or they are also injected here and use their own Hilt-injected context.
-    // The prompt for AppModule implies SecureSaltProvider(context) and StableIdentifierProvider(context).
-    // So, this class should inject those providers.
-    private val secureSaltProvider: SecureSaltProvider,
-    private val stableIdentifierProvider: StableIdentifierProvider
+    @ApplicationContext private val context: Context
 ) {
 
     companion object {
@@ -53,9 +45,8 @@ class AnonymizedIdGenerator @Inject constructor(
         // to avoid :core module's dependency on :app's BuildConfig.
         // Logging can be added in UseCases or ViewModels if needed.
 
-        // The providers now use the context they were constructed with (via Hilt).
-        val salt = secureSaltProvider.getSalt()
-        val stableId = stableIdentifierProvider.getStableIdentifier()
+        val salt = SecureSaltProvider(context).getSalt()
+        val stableId = StableIdentifierProvider(context).getStableIdentifier()
 
         if (salt == null || stableId == null) {
             // Consider logging this failure in the calling UseCase/ViewModel


### PR DESCRIPTION
This PR refactors `AnonymizedIdGenerator` from a Kotlin object to an injectable class accepting a `Context`, addressing issue #73 in `AppModule.kt`.

### Changes Made:
1.  **Refactored `AnonymizedIdGenerator.kt`:**
    *   Updated the `@Inject` constructor signature to accept `@ApplicationContext private val context: Context`.
    *   Modified the `generate()` method to initialize `SecureSaltProvider(context)` and `StableIdentifierProvider(context)` locally using the injected Context, ensuring existing hashing logic remains functional.
2.  **Updated `AppModule.kt`:**
    *   Updated the explicit `provideAnonymizedIdGenerator` provider block to pass the Hilt-provided `@ApplicationContext context: Context` directly to the `AnonymizedIdGenerator(context)` constructor.
    *   Removed a large block of duplicate, malformed legacy `@Provides` methods for `AnonymizedIdGenerator` that were cluttering the DI configuration file.

### Impact:
*   Strictly satisfies the requested interface changes for Hilt injection (`class AnonymizedIdGenerator @Inject constructor(@ApplicationContext private val context: Context)`).
*   Cleans up `AppModule.kt` and resolves potential duplicate binding issues from the legacy provider blocks.

---
*PR created automatically by Jules for task [7658805741525927254](https://jules.google.com/task/7658805741525927254) started by @Craigzyness*